### PR TITLE
Use `prepare`, not `postinstall` lifecycle script

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "clean-install": "yarn install && git checkout -- .vscode/settings.json '.yarn/*/LICENSE'",
     "compile": "yarn run -B tsc && yarn run -B esbuild --bundle --external:vscode --outdir=./build/ --platform=node --sourcemap=inline ./lib/event-curator.js",
     "lint": "yarn run -B eslint --max-warnings 0 src",
-    "postinstall": "yarn sdks vscode",
+    "prepare": "yarn sdks vscode",
     "repatch": "git add -- package.json && yarn patch-commit -s \"$1\" && git checkout -- package.json && yarn clean-install",
     "test": "yarn run -B jest",
     "upgrade-all": "printf >&2 '%s\\n\\t%s\\n' 'Run the following command line manually:' 'yarn set version stable && yarn install && yarn upgrade-packages' && false",


### PR DESCRIPTION
A `postinstall` script will run even if the package is installed as a dependency.  
This is undesirable because the `yarn sdks` command is only required while developing the package, and will in fact fail when invoked from a depending projects.

This PR replaces the `postinstall` invocation by a `prepare` script, which is guaranteed to be ignored if this package is installed as a dependency.
