### PR TITLE
updated filters

### DIFF
--- a/src/event-curator.ts
+++ b/src/event-curator.ts
@@ -12,6 +12,7 @@ import {
   relevantChangeEventsByScheme,
   relevantTextDocumentsByLanguage,
   relevantTextDocumentsByScheme,
+  selectorSpecifiesLanguage,
 } from "./event-curator/filters";
 import { stream } from "./event-curator/stream";
 import { throttleEvent } from "./event-curator/throttle";
@@ -37,39 +38,54 @@ export class EventCurator {
   onDidInitiallyFindRelevantTextDocument(
     ...args: Parameters<Event<TextDocument>>
   ) {
-    return stream(EventCurator.#onDidInitiallyFindTextDocument)
-      .select(relevantTextDocumentsByScheme)
-      .select(relevantTextDocumentsByLanguage(this.#config),
-      )(...args);
+    const _stream = stream(EventCurator.#onDidInitiallyFindTextDocument)
+    _stream.select(relevantTextDocumentsByScheme)
+
+    if(selectorSpecifiesLanguage(this.#config)) {
+      _stream.select(relevantTextDocumentsByLanguage(this.#config))
+    }
+
+    return _stream(...args)
   }
 
   onDidChangeRelevantTextDocument(
     ...args: Parameters<Event<TextDocument>>
   ) {
-    return stream(workspace.onDidChangeTextDocument)
-      .select(relevantChangeEventsByScheme)
-      .select(relevantChangeEventsByLanguage(this.#config))
-      .map(throttleEvent(
-        this.#config.changeEventThrottleMillis, (e) => e.document))
-      .select(ignoreIfAlreadyClosed,
-      )(...args);
+    const _stream = stream(workspace.onDidChangeTextDocument)
+    _stream.select(relevantChangeEventsByScheme)
+
+    if(selectorSpecifiesLanguage(this.#config)) {
+      _stream.select(relevantChangeEventsByLanguage(this.#config))
+    }
+
+    const throttledStream = _stream.map(throttleEvent(
+      this.#config.changeEventThrottleMillis, (e) => e.document))
+    throttledStream.select(ignoreIfAlreadyClosed)
+
+    return throttledStream(...args)
   }
 
   onDidOpenRelevantTextDocument(
     ...args: Parameters<Event<TextDocument>>
   ) {
-    return stream(workspace.onDidOpenTextDocument)
-      .select(relevantTextDocumentsByScheme)
-      .select(relevantTextDocumentsByLanguage(this.#config),
-      )(...args);
+    const _stream = stream(workspace.onDidOpenTextDocument)
+    _stream.select(relevantTextDocumentsByScheme)
+
+    if(selectorSpecifiesLanguage(this.#config)) {
+      _stream.select(relevantTextDocumentsByLanguage(this.#config))
+    }
+
+    return _stream(...args)
   }
 
   onDidCloseRelevantTextDocument(
     ...args: Parameters<Event<TextDocument>>
   ) {
-    return stream(workspace.onDidCloseTextDocument)
-      .select(relevantTextDocumentsByScheme)
-      .select(relevantTextDocumentsByLanguage(this.#config),
-      )(...args);
+    const _stream = stream(workspace.onDidCloseTextDocument)
+    _stream.select(relevantTextDocumentsByScheme)
+    if(selectorSpecifiesLanguage(this.#config)) {
+      _stream.select(relevantTextDocumentsByLanguage(this.#config))
+    }
+    return _stream(...args)
   }
 }

--- a/src/event-curator/filters.ts
+++ b/src/event-curator/filters.ts
@@ -10,23 +10,60 @@ import { EventStreamFunction } from "./stream";
 
 const schemesToExclude: string[] = ["git", "gitfs", "output", "vscode"];
 
+/**
+ * Determines if a DocumentSelector specifies a language constraint.
+ * 
+ * A DocumentSelector can specify a language in several ways:
+ * - As a string (which represents a language ID)
+ * - As an array containing language IDs or DocumentFilters with language properties
+ * - As a DocumentFilter object with a language property
+ * 
+ * @param selector The DocumentSelector to check
+ * @returns true if the selector specifies a language constraint, false otherwise
+ */
+function selectorSpecifiesLanguage(selector: DocumentSelector): boolean {
+  if (typeof selector === "string") {
+    return !!selector;
+  }
+  if (Array.isArray(selector)) {
+    return selector.some(selectorSpecifiesLanguage);
+  }
+  if (
+    typeof selector === "object" &&
+    selector !== null &&
+    "language" in selector &&
+    selector.language
+  ) {
+    return true;
+  }
+  return false;
+}
+
 export function relevantChangeEventsByLanguage(
   selector: DocumentSelector,
 ): EventStreamFunction<TextDocumentChangeEvent, TextDocumentChangeEvent, []> {
+  const shouldFilterByLanguage = selectorSpecifiesLanguage(selector);
   return (event) => {
+    if (!shouldFilterByLanguage) {
+      return event;
+    }
     return select((e) => !!languages.match(selector, e.document), event);
-  }
+  };
 }
 
 export function relevantTextDocumentsByLanguage(
   selector: DocumentSelector,
 ): EventStreamFunction<TextDocument, TextDocument, []> {
+  const shouldFilterByLanguage = selectorSpecifiesLanguage(selector);
   return (event) => {
+    if (!shouldFilterByLanguage) {
+      return event;
+    }
     return select(
       (document) => !!languages.match(selector, document),
       event,
     );
-  }
+  };
 }
 
 export function relevantChangeEventsByScheme(

--- a/src/event-curator/filters.ts
+++ b/src/event-curator/filters.ts
@@ -12,16 +12,18 @@ const schemesToExclude: string[] = ["git", "gitfs", "output", "vscode"];
 
 /**
  * Determines if a DocumentSelector specifies a language constraint.
- * 
+ *
  * A DocumentSelector can specify a language in several ways:
  * - As a string (which represents a language ID)
- * - As an array containing language IDs or DocumentFilters with language properties
+ * - As an array containing language IDs or DocumentFilters with
+ *    language properties
  * - As a DocumentFilter object with a language property
- * 
+ *
  * @param selector The DocumentSelector to check
- * @returns true if the selector specifies a language constraint, false otherwise
+ * @returns true if the selector specifies a language constraint,
+ *    false otherwise
  */
-function selectorSpecifiesLanguage(selector: DocumentSelector): boolean {
+export function selectorSpecifiesLanguage(selector: DocumentSelector): boolean {
   if (typeof selector === "string") {
     return !!selector;
   }
@@ -42,28 +44,20 @@ function selectorSpecifiesLanguage(selector: DocumentSelector): boolean {
 export function relevantChangeEventsByLanguage(
   selector: DocumentSelector,
 ): EventStreamFunction<TextDocumentChangeEvent, TextDocumentChangeEvent, []> {
-  const shouldFilterByLanguage = selectorSpecifiesLanguage(selector);
   return (event) => {
-    if (!shouldFilterByLanguage) {
-      return event;
-    }
     return select((e) => !!languages.match(selector, e.document), event);
-  };
+  }
 }
 
 export function relevantTextDocumentsByLanguage(
   selector: DocumentSelector,
 ): EventStreamFunction<TextDocument, TextDocument, []> {
-  const shouldFilterByLanguage = selectorSpecifiesLanguage(selector);
   return (event) => {
-    if (!shouldFilterByLanguage) {
-      return event;
-    }
     return select(
       (document) => !!languages.match(selector, document),
       event,
     );
-  };
+  }
 }
 
 export function relevantChangeEventsByScheme(


### PR DESCRIPTION
If no languages ​​are entered in the configuration then the `relevantChangeEventsByLanguage` and `relevantTextDocumentsByLanguage` actions will react to changes in any language files.